### PR TITLE
Remove noisey logging statement

### DIFF
--- a/lib/kafka/fetcher.rb
+++ b/lib/kafka/fetcher.rb
@@ -209,7 +209,8 @@ module Kafka
     rescue NoPartitionsToFetchFrom
       backoff = @max_wait_time > 0 ? @max_wait_time : 1
 
-      @logger.info "There are no partitions to fetch from, sleeping for #{backoff}s"
+      # This logging statement was causing us to log millions of times
+      # @logger.info "There are no partitions to fetch from, sleeping for #{backoff}s"
       sleep backoff
 
       []


### PR DESCRIPTION
The logging statement removed in this PR currently represents ~7% of production log events, and ~66% of staging log events. 

I decided to remove the logging with a forked version of the library over a monkey patch, because it seemed less likely someone would go and accidentally upgrade the gem and break thing. 

Once this PR is merged I will make a follow up PR in the monolith to use this fork's branch. 

This is a short term fix, and long term we should switch to use a better kafka library. 